### PR TITLE
fix(colors): Parse 2nd argument as empty when not providing

### DIFF
--- a/colors.sh
+++ b/colors.sh
@@ -30,7 +30,7 @@ STYLE_BOLD_UNDERLINE='1;4'
 # Function to get color combinations
 color-with-style() {
   local color=$1
-  local style=$2
+  local style=${2:-}
   
   local color_var_name
   printf -v color_var_name "COLOR_%s" "$color"


### PR DESCRIPTION
It fixes the `/dev/stdin: line 33: $2: unbound variable`

<img width="1206" height="496" alt="image" src="https://github.com/user-attachments/assets/8f05adb5-8bd5-4f72-a929-c4e8ebc691dd" />
